### PR TITLE
Add option to connect using TCP client. 

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,12 +108,20 @@ Example on Windows:
 python meshbot.py --port COM7
 ```
 
+Example using TCP client:
+
+```
+python meshbot.py --host meshtastic.local
+or
+python meshbot.py --host 192.168.0.100
+```
+
 ## Bot interaction
 
 You bot will be accessible through the meshtastic mesh network through the node name. DM the bot/node and issue any of the following commands:
 
 - #test : receive a test message
-- #test-detail : as #test above only more detail e.g snr,rssi, hop count (thanks to [rohanki](https://github.com/rohanki))
+- #tst-detail : as #test above only more detail e.g snr,rssi, hop count (thanks to [rohanki](https://github.com/rohanki))
 - #weather : local weather report
 - #tides : tide info (dont forget to change the default town in the source)
 - #whois #xxxx : retrieve name and node info for a node based on last 4 chars of address

--- a/meshbot.py
+++ b/meshbot.py
@@ -242,7 +242,6 @@ def message_listener(packet, interface):
             elif "#tst-detail" in message:
                 transmission_count += 1
                 testreply = "🟢 ACK."
-                print(str(packet["hopStart"]))
                 if "hopStart" in packet:
                     if (packet["hopStart"] - packet["hopLimit"]) == 0:
                         testreply += "Received Directly at "

--- a/meshbot.py
+++ b/meshbot.py
@@ -50,6 +50,7 @@ import yaml
 
 try:
     import meshtastic.serial_interface
+    import meshtastic.tcp_interface
     from pubsub import pub
 except ImportError:
     print(
@@ -238,15 +239,16 @@ def message_listener(packet, interface):
             elif "#test" in message:
                 transmission_count += 1
                 interface.sendText("🟢 ACK", wantAck=True, destinationId=sender_id)
-            elif "#test-detail" in message:
+            elif "#tst-detail" in message:
                 transmission_count += 1
                 testreply = "🟢 ACK."
+                print(str(packet["hopStart"]))
                 if "hopStart" in packet:
                     if (packet["hopStart"] - packet["hopLimit"]) == 0:
-                        testreply = testreply + "Received Directly at "
+                        testreply += "Received Directly at "
                     else:
-                        testreply = testreply + "Received from " + str(packet["hopStart"] - packet["hopLimit"]) + "hop(s) away at"
-                testreply = testreply + str(packet["rxRssi"]) + "dB, SNR: " + str(packet["rxSnr"]) + "dB (" + str(int(packet["rxSnr"] + 10 * 5)) + "%)"
+                        testreply += "Received from " + str(packet["hopStart"] - packet["hopLimit"]) + "hop(s) away at"
+                testreply += str(packet["rxRssi"]) + "dB, SNR: " + str(packet["rxSnr"]) + "dB (" + str(int(packet["rxSnr"] + 10 * 5)) + "%)"
                 interface.sendText(testreply, wantAck=True, destinationId=sender_id)
             elif "#whois #" in message:
                 message_parts = message.split("#")
@@ -420,12 +422,17 @@ def main():
     parser = argparse.ArgumentParser(description="Meshbot a bot for Meshtastic devices")
     parser.add_argument("--port", type=str, help="Specify the serial port to probe")
     parser.add_argument("--db", type=str, help="Specify DB: mpowered or liam")
+    parser.add_argument("--host", type=str, help="Specify meshtastic host (IP address) if using API")
 
     args = parser.parse_args()
 
     if args.port:
         serial_ports = [args.port]
         logger.info(f"Serial port {serial_ports}\n")
+    elif args.host:
+        ip_host = args.host
+        print(ip_host)
+        logger.info(f"Meshtastic API host {ip_host}\n")
     else:
         serial_ports = find_serial_ports()
         if serial_ports:
@@ -450,7 +457,11 @@ def main():
         logger.info(f"Default DB: {DBFILENAME}")
 
     logger.info(f"Press CTRL-C x2 to terminate the program")
-    interface = meshtastic.serial_interface.SerialInterface(serial_ports[0])
+
+    if args.host:
+        interface = meshtastic.tcp_interface.TCPInterface(hostname=ip_host,noProto=False)
+    else:
+        interface = meshtastic.serial_interface.SerialInterface(serial_ports[0])
     pub.subscribe(message_listener, "meshtastic.receive")
 
     # Start a separate thread for refreshing data periodically

--- a/requirements.txt
+++ b/requirements.txt
@@ -56,7 +56,7 @@ protobuf==5.26.1
 ptyprocess==0.7.0
 pycodestyle==2.11.1
 pycparser==2.21
-pycrypto==2.6.1
+pycryptodome==3.20.0
 Pygments==2.17.2
 pylint==3.1.0
 pyparsing==3.1.2


### PR DESCRIPTION
Updated to include the option to connect to a meshtastic device using the TCP client API. Allows meshbot to connect to a meshtastic device that is connected by WiFi and not serial.
Also updated name of #test-detail to be #tst-detail, as python matches #test-detail as #test (as logic test is if "#test" in message:).
Updated requirements.txt to use pycryptodome as pycrypto has been depreciated.